### PR TITLE
Fix Decap CMS config.yml 404 on the live /admin page

### DIFF
--- a/frontend/public/admin/index.html
+++ b/frontend/public/admin/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="robots" content="noindex" />
   <title>Content Manager</title>
+  <link href="/admin/config.yml" type="text/yaml" rel="cms-config-url">
 </head>
 <body>
   <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>


### PR DESCRIPTION
Visiting /admin (no trailing slash) leaves the browser URL at /admin#/ once Decap's router mounts. Decap's default relative fetch of config.yml then resolves against that URL and hits /config.yml at the site root instead of /admin/config.yml. On Vercel that path falls through to the SPA catch-all and returns the main app's index.html, which Decap can't parse as YAML -- hence every top-level config key reporting as "missing". Pinning the config location via an absolute <link rel="cms-config-url"> tag makes it resolve correctly regardless of trailing slash.