### PR TITLE
Fix GitHub OAuth redirect_uri using http instead of https

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Initialize the Express application
 const app = express();
+// Render terminates TLS at its edge and forwards requests over plain HTTP;
+// without this, req.protocol reports "http" even for HTTPS visitors, which
+// breaks the GitHub OAuth redirect_uri built below.
+app.set('trust proxy', true);
 app.use(cors())
 app.use('/game-covers', express.static(join(__dirname, 'game-covers')));
 app.use('/article-images', express.static(join(__dirname, 'article-images')));


### PR DESCRIPTION
Render terminates TLS at its edge and proxies to the app over plain HTTP, so req.protocol reported "http" for HTTPS visitors, building a redirect_uri that didn't match the https:// callback registered on the GitHub OAuth App ("redirect_uri is not associated with this application"). Enabling trust proxy makes Express read the original scheme from Render's X-Forwarded-Proto header instead.