### PR TITLE
Improve mobile responsiveness across the site

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,6 +4,10 @@
     opacity: 1 !important;
     transform: none !important;
   }
+
+  .fit-content {
+    min-width: 0;
+  }
 }
 
 .fit-content {

--- a/frontend/src/components/chatbot/Chatbot.css
+++ b/frontend/src/components/chatbot/Chatbot.css
@@ -103,3 +103,23 @@ button {
 .chat-container.open {
     visibility: visible;
 }
+
+@media screen and (max-width: 767px) {
+    .chat-container {
+        width: calc(100vw - 2rem);
+        max-width: 300px;
+    }
+
+    .chat-messages {
+        height: 240px;
+    }
+
+    .chatbot-icon {
+        width: 60px;
+        height: 60px;
+    }
+
+    .chatbot-icon.open {
+        bottom: 23rem;
+    }
+}

--- a/frontend/src/components/navbar/NavBar.css
+++ b/frontend/src/components/navbar/NavBar.css
@@ -104,4 +104,17 @@
     .site-navbar-links .site-navbar-link.active::after {
         display: none;
     }
+
+    .site-navbar-toggle {
+        padding: 0.625rem;
+        min-width: 44px;
+        min-height: 44px;
+    }
+
+    .mobile-cta {
+        margin-top: 0.75rem;
+        padding-top: 0.75rem;
+        border-top: 1px solid rgba(0, 0, 0, 0.1);
+        gap: 1.25rem !important;
+    }
 }

--- a/frontend/src/components/network_graph/NetworkGraph.css
+++ b/frontend/src/components/network_graph/NetworkGraph.css
@@ -17,6 +17,13 @@
     cursor: grabbing;
 }
 
+@media screen and (max-width: 767px) {
+    .network-graph-container {
+        height: 60vh;
+        min-height: 380px;
+    }
+}
+
 .pill-button {
     border-radius: var(--radius-pill);
     padding: 4px 8px;

--- a/frontend/src/fonts.css
+++ b/frontend/src/fonts.css
@@ -308,4 +308,47 @@
     letter-spacing: 0px;
   }
 
+  /*----------------Mobile Responsive Overrides-------------------*/
+  @media screen and (max-width: 767px) {
+    .display-1-large {
+      font-size: 40px;
+      line-height: 48px;
+    }
+
+    .display-2-large {
+      font-size: 36px;
+      line-height: 44px;
+    }
+
+    .display-3-large {
+      font-size: 32px;
+      line-height: 40px;
+    }
+
+    .headline-1-large {
+      font-size: 28px;
+      line-height: 36px;
+    }
+
+    .headline-2-large {
+      font-size: 26px;
+      line-height: 34px;
+    }
+
+    .headline-3-large {
+      font-size: 22px;
+      line-height: 28px;
+    }
+
+    .headline-4-large {
+      font-size: 20px;
+      line-height: 28px;
+    }
+
+    .headline-5-large {
+      font-size: 18px;
+      line-height: 24px;
+    }
+  }
+
 /* sourceMappingURL=cricketFontsCSS.5f991ad743e0a025a799.css.map */

--- a/frontend/src/pages/ArticleDetail.css
+++ b/frontend/src/pages/ArticleDetail.css
@@ -49,3 +49,10 @@
 .newspaper-body img {
   max-width: 100%;
 }
+
+@media screen and (max-width: 767px) {
+  .newspaper-title {
+    font-size: 32px;
+    line-height: 38px;
+  }
+}

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -3,6 +3,15 @@
   width: 60%;
 }
 
+@media screen and (max-width: 767px) {
+  .header-container {
+    width: 100%;
+    height: auto;
+    min-height: calc(100vh - var(--navbar-height));
+    padding: 2rem 0;
+  }
+}
+
 .hero-name-wrap {
   display: inline-block;
 }

--- a/frontend/src/pages/Resume.css
+++ b/frontend/src/pages/Resume.css
@@ -11,3 +11,7 @@
   height: 100%;
   border: none;
 }
+
+.resume-mobile-link {
+  width: fit-content;
+}

--- a/frontend/src/pages/Resume.js
+++ b/frontend/src/pages/Resume.js
@@ -6,6 +6,14 @@ const Resume = () => {
         <div className="App-content-stuff d-flex flex-column">
             <p data-aos="fade-left" className='display-3-large sonic-blue-text'>My Resume</p>
             <div data-aos="fade-left" className='topic-line sonic-red'></div>
+            <a
+                href="/MichaelAni_Resume.pdf"
+                target="_blank"
+                rel="noreferrer"
+                className='btn-cta resume-mobile-link d-md-none mb-4'
+            >
+                Open Resume PDF
+            </a>
             <div data-aos="fade-left" className='resume-preview-frame mb-5'>
                 <iframe src="/MichaelAni_Resume.pdf" title="Michael Ani Resume" className='resume-embed'></iframe>
             </div>


### PR DESCRIPTION
Adds mobile-only overrides (scoped to the existing 767px breakpoint) for the hero layout, page-title typography, chatbot widget sizing, navbar tap targets, resume PDF fallback, and 3D graph height, since these previously used fixed desktop-tuned dimensions with no mobile treatment. Desktop (>=768px) styling is unaffected.